### PR TITLE
CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,54 @@ df = entry.read()
 ```
 
 This will automatically load that dataset into a Pandas dataframe, or a GeoDataFrame, depending on the source format.
+
+### Command Line Interface
+
+`intake-dcat` provides a small command line interface for some common operations.
+These are invoked using `intake-dcat <subcommand> <options>`
+
+#### The `mirror` command
+
+This command loads a manifest file that lists a set of DCAT entries,
+uploads them to a specified s3 bucket, and outputs a new catalog with identical entries
+pointing to the bucket.
+
+An example manifest is given by
+```yml
+# Name of the LA open data portal
+la-open-data:
+  # URL to the open data portal catalog
+  url: https://data.lacity.org/data.json
+  # The s3 bucket to upload the data to
+  bucket_uri: s3://my-bucket
+  # A list of data resources to mirror
+  items:
+    lapd_metrics: https://data.lacity.org/api/views/t6kt-2yic
+# Name of the LA GeoHub data portal
+la-geohub:
+  # URL to the open data portal catalog
+  url: http://geohub.lacity.org/data.json
+  # The s3 bucket to upload the data to
+  bucket_uri: s3://my-bucket
+  # A list of data resources to mirror
+  items:
+    bikeways: http://geohub.lacity.org/datasets/2602345a7a8549518e8e3c873368c1d9_0 
+    city_boundary: http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7
+```
+
+This can be mirrored using the command
+
+```bash
+intake-dcat mirror manifest.yml > new-catalog.yml
+```
+
+This command uses the `boto3` library and assumes it can find AWS credentials.
+
+#### The `create` command
+
+This command creates a new intake catalog from a DCAT catalog, and outputs it to standard out.
+An example command is given by
+
+```bash
+intake-dcat create data.lacity.org/data.json > catalog.yml
+```

--- a/intake_dcat/catalog.py
+++ b/intake_dcat/catalog.py
@@ -1,4 +1,5 @@
 import requests
+import yaml
 
 from intake.catalog import Catalog
 from intake.catalog.local import LocalCatalogEntry
@@ -49,6 +50,19 @@ class DCATCatalog(Catalog):
             for entry in catalog["dataset"]
             if should_include_entry(entry)
         }
+
+    def serialize(self):
+        """
+        Serialize the catalog to yaml.
+
+        Returns
+        -------
+        A string with the yaml-formatted catalog.
+        """
+        output = {"metadata": self.metadata, "sources": {}}
+        for key, entry in self.items():
+            output["sources"][key] = yaml.safe_load(entry.yaml())["sources"][key]
+        return yaml.dump(output)
 
 
 class DCATEntry(LocalCatalogEntry):

--- a/intake_dcat/cli.py
+++ b/intake_dcat/cli.py
@@ -11,12 +11,19 @@ from .util import mirror_data
 
 class Mirror(Subcommand):
     """
-    Mirror a catalog subset specified in a manifest to a remote bucket.
+    Mirror a catalog subset specified in a manifest to a remote bucket,
+    and print the resulting subsetted catalog to stdout.
+
+
+    If --dry-run is specified, then no upload happens, but the catalog is still printed.
     """
 
     name = "mirror"
 
     def initialize(self):
+        """
+        Initialize the subcommand by adding the argparser arguments.
+        """
         self.parser.add_argument(
             "manifest",
             type=str,
@@ -36,6 +43,9 @@ class Mirror(Subcommand):
         )
 
     def invoke(self, args):
+        """
+        Invoke the command.
+        """
         upload = not args.dry_run
         catalog = mirror_data(
             args.manifest, upload=upload, name=args.name, version=args.version
@@ -51,6 +61,9 @@ class Create(Subcommand):
     name = "create"
 
     def initialize(self):
+        """
+        Initialize the subcommand by adding the argparser arguments.
+        """
         self.parser.add_argument("uri", metavar="URI", type=str, help="Catalog URI")
         self.parser.add_argument(
             "--version", metavar="VERSION", type=str, help="Catalog version"
@@ -60,6 +73,9 @@ class Create(Subcommand):
         )
 
     def invoke(self, args):
+        """
+        Invoke the command.
+        """
         version = args.version or None
         name = args.name or ""
         metadata = {"name": name, "version": version}

--- a/intake_dcat/cli.py
+++ b/intake_dcat/cli.py
@@ -1,0 +1,72 @@
+import argparse
+import sys
+import yaml
+
+from intake.cli.bootstrap import main as run
+from intake.cli.util import Subcommand
+
+from .catalog import DCATCatalog
+from .util import mirror_data
+
+
+class Mirror(Subcommand):
+    """
+    Mirror a catalog subset specified in a manifest to a remote bucket.
+    """
+
+    name = "mirror"
+
+    def initialize(self):
+        self.parser.add_argument(
+            "manifest",
+            type=str,
+            metavar="MANIFEST",
+            help="Path to a manifest YAML file",
+        )
+        self.parser.add_argument(
+            "--dry-run",
+            help="If this flag is given, no upload occurs",
+            action="store_true",
+        )
+
+    def invoke(self, args):
+        upload = not args.dry_run
+        catalog = mirror_data(args.manifest, upload=upload)
+        print(yaml.dump(catalog))
+
+
+class Create(Subcommand):
+    """
+    Create an intake YAML catalog from a DCAT catalog and print it to stdout.
+    """
+
+    name = "create"
+
+    def initialize(self):
+        self.parser.add_argument("uri", metavar="URI", type=str, help="Catalog URI")
+        self.parser.add_argument(
+            "--version", metavar="VERSION", type=str, help="Catalog version"
+        )
+        self.parser.add_argument(
+            "--name", metavar="VERSION", type=str, help="Catalog name"
+        )
+
+    def invoke(self, args):
+        version = args.version or None
+        name = args.name or ""
+        catalog = DCATCatalog(args.uri, name=name)
+        new_catalog = {"metadata": {"name": name, "version": version}, "sources": {}}
+        for key, entry in catalog.items():
+            new_catalog["sources"][key] = yaml.safe_load(entry.yaml())["sources"][key]
+        print(yaml.dump(new_catalog))
+
+
+subcommands = [Mirror, Create]
+
+
+def main(argv=None):
+    return run("Intake DCAT CLI", subcommands, argv or sys.argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/intake_dcat/cli.py
+++ b/intake_dcat/cli.py
@@ -62,11 +62,9 @@ class Create(Subcommand):
     def invoke(self, args):
         version = args.version or None
         name = args.name or ""
-        catalog = DCATCatalog(args.uri, name=name)
-        new_catalog = {"metadata": {"name": name, "version": version}, "sources": {}}
-        for key, entry in catalog.items():
-            new_catalog["sources"][key] = yaml.safe_load(entry.yaml())["sources"][key]
-        print(yaml.dump(new_catalog))
+        metadata = {"name": name, "version": version}
+        catalog = DCATCatalog(args.uri, name=name, metadata=metadata)
+        print(catalog.serialize())
 
 
 subcommands = [Mirror, Create]

--- a/intake_dcat/cli.py
+++ b/intake_dcat/cli.py
@@ -28,10 +28,18 @@ class Mirror(Subcommand):
             help="If this flag is given, no upload occurs",
             action="store_true",
         )
+        self.parser.add_argument(
+            "--version", metavar="VERSION", type=str, help="Catalog version"
+        )
+        self.parser.add_argument(
+            "--name", metavar="VERSION", type=str, help="Catalog name"
+        )
 
     def invoke(self, args):
         upload = not args.dry_run
-        catalog = mirror_data(args.manifest, upload=upload)
+        catalog = mirror_data(
+            args.manifest, upload=upload, name=args.name, version=args.version
+        )
         print(yaml.dump(catalog))
 
 

--- a/intake_dcat/util.py
+++ b/intake_dcat/util.py
@@ -13,7 +13,7 @@ from .catalog import DCATCatalog
 fs = s3fs.S3FileSystem()
 
 
-def mirror_data(manifest_file, upload=True):
+def mirror_data(manifest_file, upload=True, name=None, version=None):
     """
     Given a path the a manifest.yml file, download the relevant data,
     upload it to the specified bucket, and return a new catalog
@@ -32,7 +32,7 @@ def mirror_data(manifest_file, upload=True):
     -------
     A dictionary containing data for the new catalog.
     """
-    new_catalog = {"sources": {}}
+    new_catalog = {"metadata": {"name": name, "version": version}, "sources": {}}
     with open(manifest_file) as f:
         manifest = yaml.safe_load(f)
         for catalog_name, catalog_data in manifest.items():

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ setup(
         'intake-geopandas>=0.2.1',
         's3fs',
     ],
+    entry_points={
+        'console_scripts': [
+            'intake-dcat = intake_dcat.cli:main'
+        ]
+    },
     license='Apache-2.0 license',
     zip_safe=False,
     keywords='intake dcat',


### PR DESCRIPTION
Adds a fairly simple CLI to the library.
Examples:
```bash
# Create a new intake catalog from LA open data and put it in catalog.yml
intake-dcat create data.lacity.org/data.json > catalog.yml 
```

```bash
# Construct a catalog specified by the manifest and upload it to a remote storage bucket.
intake-dcat mirror manifest.yml > catalog.yml
```
These could be used for CI and Makefiles.