### PR TITLE
Handle zipped remote resources

### DIFF
--- a/intake_dcat/util.py
+++ b/intake_dcat/util.py
@@ -62,7 +62,7 @@ def _construct_remote_entry(bucket_uri, entry, name, directory="", upload=True):
     old_uri = entry["args"]["urlpath"]
     new_uri = _construct_remote_uri(bucket_uri, entry, name, directory)
     new_entry["args"]["urlpath"] = new_uri
-    if False:
+    if upload:
         _upload_remote_data(old_uri, new_uri)
     return new_entry
 

--- a/intake_dcat/util.py
+++ b/intake_dcat/util.py
@@ -60,20 +60,20 @@ def _upload_remote_data(old_uri, new_uri, dir=None):
 def _construct_remote_entry(bucket_uri, entry, name, directory="", upload=True):
     new_entry = copy.deepcopy(entry)
     old_uri = entry["args"]["urlpath"]
-    new_uri = _construct_remote_uri(bucket_uri, entry, name, directory)
-    new_entry["args"]["urlpath"] = new_uri
+    upload_uri = _construct_remote_uri(bucket_uri, entry, name, directory)
+    compression = _get_compression_for_entry(entry)
+    access_uri = f"{compression}+{upload_uri}" if compression else upload_uri
+    new_entry["args"]["urlpath"] = access_uri
     if upload:
-        _upload_remote_data(old_uri, new_uri)
+        _upload_remote_data(old_uri, upload_uri)
     return new_entry
 
 
 def _construct_remote_uri(bucket_uri, entry, name, directory=""):
     urlpath = entry["args"].get("urlpath")
     ext = _get_extension_for_entry(entry)
-    compression = _get_compression_for_entry(entry)
     key = f"{directory.strip('/')}/{name}{ext}" if directory else f"{name}{ext}"
-    uri = f"{bucket_uri.strip('/')}/{key}"
-    return f"{compression}+{uri}" if compression else uri
+    return f"{bucket_uri.strip('/')}/{key}"
 
 
 def _get_extension_for_entry(intake_entry):

--- a/intake_dcat/util.py
+++ b/intake_dcat/util.py
@@ -62,13 +62,46 @@ def _construct_remote_entry(bucket_uri, entry, name, directory="", upload=True):
     old_uri = entry["args"]["urlpath"]
     new_uri = _construct_remote_uri(bucket_uri, entry, name, directory)
     new_entry["args"]["urlpath"] = new_uri
-    if upload:
+    if False:
         _upload_remote_data(old_uri, new_uri)
     return new_entry
 
 
 def _construct_remote_uri(bucket_uri, entry, name, directory=""):
     urlpath = entry["args"].get("urlpath")
-    _, ext = os.path.splitext(urlpath)
+    ext = _get_extension_for_entry(entry)
     key = f"{directory.strip('/')}/{name}{ext}" if directory else f"{name}{ext}"
     return f"{bucket_uri.strip('/')}/{key}"
+
+
+def _get_extension_for_entry(intake_entry):
+    """
+    Given an intake catalog entry, return a file extension for it, which can
+    be used to construct names when re-uploading the files to s3. It would be
+    nice to be able to rely on extensions in the URL, but that is not
+    particularly reliable. Instead, we infer an extension from the driver and
+    args that are used. The following extensions are returned:
+
+        GeoJSON: ".geojson"
+        Zipped Shapefile: ".zip"
+        Shapefile: ".shp"
+        CSV: ".csv"
+    """
+    driver = intake_entry.get("driver")
+    args = intake_entry.get("args", {})
+    if driver == "geojson" or driver == "intake_geopandas.geopandas.GeoJSONSource":
+        return ".geojson"
+    elif (
+        driver == "shapefile" or driver == "intake_geopandas.geopandas.ShapefileSource"
+    ):
+        compression = args.get("geopandas_kwargs", {}).get("compression")
+        if compression == "zip":
+            return ".zip"
+        elif not compression:
+            return ".shp"
+        else:
+            raise ValueError(f"Unexpected compression scheme for {str(intake_entry)}")
+    elif driver == "csv" or driver == "intake.source.csv.CSVSource":
+        return ".csv"
+    else:
+        raise ValueError(f"Unsupported driver {driver}")

--- a/setup.py
+++ b/setup.py
@@ -8,31 +8,27 @@ readme = open("README.md").read() if exists("README.md") else ""
 
 
 setup(
-    name='intake-dcat',
-    description='DCAT to Intake Catalog translation layer',
+    name="intake-dcat",
+    description="DCAT to Intake Catalog translation layer",
     long_description=readme,
-    long_description_content_type='text/markdown',
-    maintainer='Ian Rose',
-    maintainer_email='ian.rose@lacity.org',
-    url='https://github.com/CityOfLosAngeles/intake-dcat',
+    long_description_content_type="text/markdown",
+    maintainer="Ian Rose",
+    maintainer_email="ian.rose@lacity.org",
+    url="https://github.com/CityOfLosAngeles/intake-dcat",
     packages=find_packages(),
-    package_dir={'intake-dcat': 'intake-dcat'},
+    package_dir={"intake-dcat": "intake-dcat"},
     include_package_data=True,
     install_requires=[
-        'geopandas>=0.5',
-        'intake>=0.5',
-        'intake-geopandas>=0.2.2',
-        'pyyaml',
-        'requests',
-        's3fs',
+        "geopandas>=0.5",
+        "intake>=0.5",
+        "intake-geopandas>=0.2.2",
+        "pyyaml",
+        "requests",
+        "s3fs",
     ],
-    entry_points={
-        'console_scripts': [
-            'intake-dcat = intake_dcat.cli:main'
-        ]
-    },
-    license='Apache-2.0 license',
+    entry_points={"console_scripts": ["intake-dcat = intake_dcat.cli:main"]},
+    license="Apache-2.0 license",
     zip_safe=False,
-    keywords='intake dcat',
+    keywords="intake dcat",
     version=version,
 )


### PR DESCRIPTION
Fixes #10. This identifies when a resource is zipped (mostly for our purposes this means shapefiles), and adds the protocol `zip+s3://` to S3 URIs when mirroring them. This allows `fiona` to properly read those files.