### PR TITLE
Update binder environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,11 +3,12 @@ channels:
   - conda-forge
   - informaticslab
 dependencies:
-  - python=3
+  - descartes
   - geopandas>=0.5
   - intake>=0.5.0
   - intake_geopandas>=0.2.2
-  - dask>=1.2.0
+  - matplotlib
+  - python=3
   - pip:
-    - intake-dcat==0.2.0
-    - jupyterlab==1.0.0a3
+    - intake-dcat
+    - jupyterlab


### PR DESCRIPTION
Geopandas apparently dropped a hard dependency on matplotlib (which is good!), but it means we need to include it in the binder deps now.
cc @phillipwongg