### PR TITLE
Aliases

### DIFF
--- a/examples/catalogs/demo.yml
+++ b/examples/catalogs/demo.yml
@@ -1,17 +1,28 @@
 metadata:
   version: 1
 sources:
+  # Here we have two data sources for this catalog, which are themselves
+  # DCAT catalogs, one for LA open data, and the other for LA GeoHub
   la_open_data:
+    # We identify them as being loaded with the GeoHub
     driver: dcat
+    # Here we specify the args used to load the catalog
     args:
+      # The URL to the catalog
       url: https://data.lacity.org/data.json
+      # An optional name for the catalog.
       name: la-open-data
   la_geohub:
     driver: dcat
     args:
       url: http://geohub.lacity.org/data.json
       name: la_geohub
+      # We can also specify a subset of the datasets in the catalog using an "items"
+      # dictionary. If these are specified, only these datasets will be available in
+      # the resulting catalog. They will be available under the more human-readable
+      # name specified as the key.
       items:
+        # So, this dataset will be available as "bikeways"
         bikeways: http://geohub.lacity.org/datasets/2602345a7a8549518e8e3c873368c1d9_0 
         city_boundary: http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7
         bike_racks: http://geohub.lacity.org/datasets/3b022cced9704108af157d3d5eedb268_2

--- a/examples/data_source_examples.ipynb
+++ b/examples/data_source_examples.ipynb
@@ -336,7 +336,7 @@
    "source": [
     "#Remote GeoJSON\n",
     "geohub = catalog_remote_geojson.la_geohub\n",
-    "bike_racks = geohub['http://geohub.lacity.org/datasets/3b022cced9704108af157d3d5eedb268_2'].read()\n",
+    "bike_racks = geohub.bike_racks.read()\n",
     "bike_racks.head()"
    ]
   },
@@ -2531,7 +2531,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x26c47477ef0>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x16709dd49e8>"
       ]
      },
      "execution_count": 22,

--- a/examples/demo.ipynb
+++ b/examples/demo.ipynb
@@ -112,6 +112,39 @@
      "data": {
       "text/html": [
        "\n",
+       "        <h3>City Boundary</h3>\n",
+       "        <div style=\"display: flex; flex-direction: row; flex-wrap: wrap; height:256px\">\n",
+       "            <div style=\"flex: 0 0 384px; padding-right: 24px\">\n",
+       "                \n",
+       "            <p style=\"margin-bottom: 0.5em\"><b>ID:</b><a href=\"http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7\"> http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7</a></p>\n",
+       "            <p style=\"margin-bottom: 0.5em\"><b>Issued:</b> 2015-11-14T01:23:22.000Z</p>\n",
+       "            <p style=\"margin-bottom: 0.5em\"><b>Last Modified:</b> 2018-04-06T16:48:27.000Z</p>\n",
+       "            <p style=\"margin-bottom: 0.5em\"><b>Publisher:</b> unknown</p>\n",
+       "            <p style=\"margin-bottom: 0.5em\"><b>License:</b> http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7/license.json</p>\n",
+       "            <p style=\"margin-bottom: 0.5em\"><b>Download URL:</b><a href=\"http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7.geojson\"> http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7.geojson</a></p>\n",
+       "        \n",
+       "            </div>\n",
+       "            <div style=\"flex: 1 1 0; height: 100%; overflow: auto\">\n",
+       "                <p>\n",
+       "                    City Boundary \n",
+       "                </p>\n",
+       "            </div>\n",
+       "        </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7\n",
+       "City Boundary\n",
+       "City Boundary "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
        "        <h3>Bike Racks</h3>\n",
        "        <div style=\"display: flex; flex-direction: row; flex-wrap: wrap; height:256px\">\n",
        "            <div style=\"flex: 0 0 384px; padding-right: 24px\">\n",
@@ -144,39 +177,6 @@
        "Bike Racks installed where possible in the public right-of-way bike parking as close to building entrances as possible to increase security and make travelling by bike convenient. \n",
        "\n",
        "Bike Repair stations provide basic bicycle repair capability to business districts and corridors that cater to bicyclists. Repair Stations feature a stand to mount a bicycle and contain the basic tools needed to perform do-it-yourself bicycle repair including screwdrivers, wrenches, and hex tools. Repair stations also feature a heavy duty bicycle pump with a pump head for both schrader and presta valves and connect users to detailed instructions for a wide variety of bicycle repairs-just a smart phone scan away."
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "        <h3>City Boundary</h3>\n",
-       "        <div style=\"display: flex; flex-direction: row; flex-wrap: wrap; height:256px\">\n",
-       "            <div style=\"flex: 0 0 384px; padding-right: 24px\">\n",
-       "                \n",
-       "            <p style=\"margin-bottom: 0.5em\"><b>ID:</b><a href=\"http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7\"> http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7</a></p>\n",
-       "            <p style=\"margin-bottom: 0.5em\"><b>Issued:</b> 2015-11-14T01:23:22.000Z</p>\n",
-       "            <p style=\"margin-bottom: 0.5em\"><b>Last Modified:</b> 2018-04-06T16:48:27.000Z</p>\n",
-       "            <p style=\"margin-bottom: 0.5em\"><b>Publisher:</b> unknown</p>\n",
-       "            <p style=\"margin-bottom: 0.5em\"><b>License:</b> http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7/license.json</p>\n",
-       "            <p style=\"margin-bottom: 0.5em\"><b>Download URL:</b><a href=\"http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7.geojson\"> http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7.geojson</a></p>\n",
-       "        \n",
-       "            </div>\n",
-       "            <div style=\"flex: 1 1 0; height: 100%; overflow: auto\">\n",
-       "                <p>\n",
-       "                    City Boundary \n",
-       "                </p>\n",
-       "            </div>\n",
-       "        </div>\n",
-       "        "
-      ],
-      "text/plain": [
-       "http://geohub.lacity.org/datasets/09f503229d37414a8e67a7b6ceb9ec43_7\n",
-       "City Boundary\n",
-       "City Boundary "
       ]
      },
      "metadata": {},
@@ -403,8 +403,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bike_racks = geohub['http://geohub.lacity.org/datasets/3b022cced9704108af157d3d5eedb268_2'].read()\n",
-    "bikeways = geohub['http://geohub.lacity.org/datasets/2602345a7a8549518e8e3c873368c1d9_0'].read()\n",
+    "# The subsetted geohub catalog was able to rename the selected datasets\n",
+    "# so that they are nicer to read.\n",
+    "bike_racks = geohub.bike_racks.read()\n",
+    "bikeways = geohub.bikeways.read()\n",
+    "# The auto-generated open data catalog used the default identifier,\n",
+    "# which is a bit less nice to read.\n",
     "city_boundary = open_data_boundary['https://data.lacity.org/api/views/ppge-zfr4'].read()"
    ]
   },
@@ -876,7 +880,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.axes._subplots.AxesSubplot at 0x27f429f5208>"
+       "<matplotlib.axes._subplots.AxesSubplot at 0x1eecee5d0f0>"
       ]
      },
      "execution_count": 10,


### PR DESCRIPTION
If the user specifies a subset of items in the catalog via `items`, make those available under the more human-readable name.

This is a breaking change for that functionality (but not for raw views of a catalog or for mirrored catalogs).