### PR TITLE
Handle 202 responses

### DIFF
--- a/intake_dcat/__init__.py
+++ b/intake_dcat/__init__.py
@@ -1,4 +1,4 @@
-import intake
+import intake  # noqa: F401
 from .catalog import DCATCatalog
 
 __all__ = ["DCATCatalog"]

--- a/intake_dcat/catalog.py
+++ b/intake_dcat/catalog.py
@@ -122,7 +122,7 @@ class DCATEntry(LocalCatalogEntry):
             <p style="margin-bottom: 0.5em"><b>Publisher:</b> {publisher}</p>
             <p style="margin-bottom: 0.5em"><b>License:</b> {license}</p>
             <p style="margin-bottom: 0.5em"><b>Download URL:</b><a href="{download}"> {download}</a></p>
-        """
+        """  # noqa: E501
         html = f"""
         <h3>{title}</h3>
         <div style="display: flex; flex-direction: row; flex-wrap: wrap; height:256px">
@@ -137,7 +137,7 @@ class DCATEntry(LocalCatalogEntry):
         </div>
         """
 
-        return display(
+        return display(  # noqa: F821
             {
                 "text/html": html,
                 "text/plain": "\n".join([entry_id, title, description]),
@@ -152,4 +152,4 @@ def should_include_entry(dcat_entry):
     Returns True if we can find a driver to load it (GeoJSON,
     Shapefile, CSV), False otherwise.
     """
-    return get_relevant_distribution(dcat_entry) != None
+    return get_relevant_distribution(dcat_entry) is not None

--- a/intake_dcat/cli.py
+++ b/intake_dcat/cli.py
@@ -1,4 +1,3 @@
-import argparse
 import sys
 import yaml
 

--- a/intake_dcat/distributions.py
+++ b/intake_dcat/distributions.py
@@ -1,17 +1,21 @@
 import re
 
+DEFAULT_PRIORITIES = ["geojson", "shapefile", "csv"]
 
-def get_relevant_distribution(dcat_entry):
+
+def get_relevant_distribution(dcat_entry, priority=None):
     """
     Given a DCAT entry, find the most relevant distribution
     for the intake catalog. Returns a tuple of
     (intake_driver_name, distribution). In general,
     we choose the more specific formats over the less specific
-    formats. At present, they are ranked in the following order:
+    formats. By default, they are ranked in the following order:
 
         GeoJSON
         Shapefile
         CSV
+
+    You can provide a "priority" list to customize the priority.
 
     If none of these are found, None.
     If there are no distributions, it returns None.
@@ -20,15 +24,22 @@ def get_relevant_distribution(dcat_entry):
     if not distributions or not len(distributions):
         return None
 
-    for d in distributions:
-        if test_geojson(d):
-            return "geojson", geojson_driver_args(d)
-    for d in distributions:
-        if test_shapefile(d):
-            return "shapefile", shapefile_driver_args(d)
-    for d in distributions:
-        if test_csv(d):
-            return "csv", csv_driver_args(d)
+    priority = priority or DEFAULT_PRIORITIES
+    for p in priority:
+        if p.lower() == "geojson":
+            for d in distributions:
+                if test_geojson(d):
+                    return "geojson", geojson_driver_args(d)
+        elif p.lower() == "shapefile":
+            for d in distributions:
+                if test_shapefile(d):
+                    return "shapefile", shapefile_driver_args(d)
+        elif p.lower() == "csv":
+            for d in distributions:
+                if test_csv(d):
+                    return "csv", csv_driver_args(d)
+        else:
+            raise ValueError(f"Unexpected driver {p}")
 
     return None
 

--- a/intake_dcat/util.py
+++ b/intake_dcat/util.py
@@ -1,5 +1,4 @@
 import copy
-import os
 
 import requests
 import yaml
@@ -70,7 +69,6 @@ def _construct_remote_entry(bucket_uri, entry, name, directory="", upload=True):
 
 
 def _construct_remote_uri(bucket_uri, entry, name, directory=""):
-    urlpath = entry["args"].get("urlpath")
     ext = _get_extension_for_entry(entry)
     key = f"{directory.strip('/')}/{name}{ext}" if directory else f"{name}{ext}"
     return f"{bucket_uri.strip('/')}/{key}"
@@ -90,7 +88,6 @@ def _get_extension_for_entry(intake_entry):
         CSV: ".csv"
     """
     driver = intake_entry.get("driver")
-    args = intake_entry.get("args", {})
     if driver == "geojson" or driver == "intake_geopandas.geopandas.GeoJSONSource":
         return ".geojson"
     elif (

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[flake8]
+# References:
+# http://flake8.readthedocs.org/en/latest/config.html
+# http://flake8.readthedocs.org/en/latest/warnings.html#error-codes
+max-line-length = 88
+ignore=E203, W503


### PR DESCRIPTION
This PR does two things:

1. Fixes #23 . If a 202 response is received, it retries every five seconds for a few minutes before failing.
1. Fixes #22 . The user can add a "priority" arg which can let them override the default priorities of which driver to use. The default is GeoJSON, followed by  Shapefile, followed by CSV.